### PR TITLE
Fix tests, missed port and add support for Debian package config file location

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -16,7 +16,10 @@ sentinel_version = "1.1.0"
 def get_terracoin_conf():
     home = os.environ.get('HOME')
 
-    terracoin_conf = os.path.join(home, ".terracoincore/terracoin.conf")
+    terracoin_conf = "/etc/terracoincore/terracoin.conf"
+    if ( not os.path.isfile(terracoin_conf) ):
+        terracoin_conf = os.path.join(home, ".terracoincore/terracoin.conf")
+
     if sys.platform == 'darwin':
         terracoin_conf = os.path.join(home, "Library/Application Support/TerracoinCore/terracoin.conf")
 

--- a/test/integration/test_jsonrpc.py
+++ b/test/integration/test_jsonrpc.py
@@ -16,7 +16,8 @@ def test_terracoind():
     config_text = TerracoinConfig.slurp_config_file(config.terracoin_conf)
     network = 'mainnet'
     is_testnet = False
-    genesis_hash = u'00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6'
+    #genesis_hash = u'00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6'
+    genesis_hash = u'00000000804bbc6a621a9dbb564ce469f492e1ccf2d70f8a6b241e26a277afa2'
     for line in config_text.split("\n"):
         if line.startswith('testnet=1'):
             network = 'testnet'

--- a/test/unit/test_terracoin_config.py
+++ b/test/unit/test_terracoin_config.py
@@ -59,7 +59,7 @@ def test_get_rpc_creds():
         assert key in creds
     assert creds.get('user') == 'terracoinrpc'
     assert creds.get('password') == 'EwJeV3fZTyTVozdECF627BkBMnNDwQaVLakG3A4wXYyk'
-    assert creds.get('port') == 19998
+    assert creds.get('port') == 18332
 
 
 # ensure terracoin network (mainnet, testnet) matches that specified in config


### PR DESCRIPTION
This Fixes 2 tests and adds support for terracoin.conf potentially being located at /etc/terracoincore/terracoin.conf which is where the Debian package installs it to.

The other 8 failed tests are all do to the changes to the block time form 2.62 to 2.12 and for the terracoin_version in address.is_valid, all the test data needs to be updated to reflect these changes.